### PR TITLE
Version 2 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 matrix:

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014, David Stockton
+Copyright (c) 2015, David Stockton
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The recommended method of installation is [through composer](http://getcomposer.
 ```JSON
 {
     "require": {
-        "phergie/phergie-irc-plugin-react-daddy": "dev-master"
+        "phergie/phergie-irc-plugin-react-daddy": "~2"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=5.4.0",
-        "phergie/phergie-irc-bot-react": "~1"
+        "php": ">=5.5",
+        "phergie/phergie-irc-bot-react": "~2"
     },
     "require-dev": {
         "phpunit/phpunit": "4.0.*",


### PR DESCRIPTION
- Set minimum version of PHP to 5.5, use version 2 of phergie-irc-bot-react
- update readme composer version example
- your table readiness is unknown.
- Travis: Drop version 5.4 from travis and Add php 7 testing
- update license year
